### PR TITLE
Make roles configurable through .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,17 @@
+DISCORD_TOKEN=your_discord_token
+PERSONAL_SERVER=your_personal_server_id
+HSKUCW=your_hskucw_server_id
+LETTER_CHANNEL=your_letter_channel
+PG_HOST=your_pg_host
+PG_USER=your_pg_user
+PG_PASS=your_pg_pass
+PG_PORT=your_pg_port
+PG_DB=your_pg_db
+PERSONAL_ID=your_personal_id
+
+DIPLO_UMPIRE_ROLE=Diplo Umpire
+SPECTATOR_ROLE=Spectator
+DIPLOMAT_ROLE=Diplomat
+BANKER_ROLE=Banker
+NEWSPAPER_WRITER_ROLE=Newspaper Writer
+CAPTURED_ROLE=Captured

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ PG_PASS=
 PG_PORT=
 PG_DB=
 PERSONAL_ID=
+DIPLO_UMPIRE_ROLE=
+SPECTATOR_ROLE=
+DIPLOMAT_ROLE=
+BANKER_ROLE=
+NEWSPAPER_WRITER_ROLE=
+CAPTURED_ROLE=
 ```
 
 Discord token is the token for your application, as given by discord. You will also need to have the correct permissions set. I run under admin b/c I control the code... your trust may vary.
@@ -51,4 +57,10 @@ PG_PASS=your_pg_pass
 PG_PORT=your_pg_port
 PG_DB=your_pg_db
 PERSONAL_ID=your_personal_id
+DIPLO_UMPIRE_ROLE=Diplo Umpire
+SPECTATOR_ROLE=Spectator
+DIPLOMAT_ROLE=Diplomat
+BANKER_ROLE=Banker
+NEWSPAPER_WRITER_ROLE=Newspaper Writer
+CAPTURED_ROLE=Captured
 ```

--- a/diplo.py
+++ b/diplo.py
@@ -15,6 +15,12 @@ HSKUCW = int(os.getenv("HSKUCW"))
 
 
 LETTER_CHANNEL = os.getenv("LETTER_CHANNEL")
+DIPLO_UMPIRE_ROLE = os.getenv("DIPLO_UMPIRE_ROLE")
+SPECTATOR_ROLE = os.getenv("SPECTATOR_ROLE")
+DIPLOMAT_ROLE = os.getenv("DIPLOMAT_ROLE")
+BANKER_ROLE = os.getenv("BANKER_ROLE")
+NEWSPAPER_WRITER_ROLE = os.getenv("NEWSPAPER_WRITER_ROLE")
+CAPTURED_ROLE = os.getenv("CAPTURED_ROLE")
 
 
 diplo = app_commands.Group(
@@ -38,12 +44,12 @@ async def send_letter(
     message: str,
 ):
     # TODO - these roles should also be configurable
-    u_role = get(interaction.guild.roles, name="Diplo Umpire")
-    s_role = get(interaction.guild.roles, name="Spectator")
-    d_role = get(interaction.guild.roles, name="Diplomat")
-    b_role = get(interaction.guild.roles, name="Banker")
-    n_role = get(interaction.guild.roles, name="Newspaper Writer")
-    c_role = get(interaction.guild.roles, name="Captured")
+    u_role = get(interaction.guild.roles, name=DIPLO_UMPIRE_ROLE)
+    s_role = get(interaction.guild.roles, name=SPECTATOR_ROLE)
+    d_role = get(interaction.guild.roles, name=DIPLOMAT_ROLE)
+    b_role = get(interaction.guild.roles, name=BANKER_ROLE)
+    n_role = get(interaction.guild.roles, name=NEWSPAPER_WRITER_ROLE)
+    c_role = get(interaction.guild.roles, name=CAPTURED_ROLE)
     now_stamp = int(datetime.now().timestamp())
 
     # max_letter_size = 1900

--- a/loans.py
+++ b/loans.py
@@ -13,6 +13,8 @@ HSKUCW = int(os.getenv("HSKUCW"))
 
 
 LETTER_CHANNEL = os.getenv("LETTER_CHANNEL")
+DIPLO_UMPIRE_ROLE = os.getenv("DIPLO_UMPIRE_ROLE")
+SPECTATOR_ROLE = os.getenv("SPECTATOR_ROLE")
 
 
 loans = app_commands.Group(
@@ -36,8 +38,8 @@ async def submit_bid(
 ):
     # request metadata
     trole_id = interaction.user.top_role.id
-    u_role = get(interaction.guild.roles, name="Diplo Umpire")
-    s_role = get(interaction.guild.roles, name="Spectator")
+    u_role = get(interaction.guild.roles, name=DIPLO_UMPIRE_ROLE)
+    s_role = get(interaction.guild.roles, name=SPECTATOR_ROLE)
     if interaction.user.nick is None:
         usr = interaction.user.name
     else:


### PR DESCRIPTION
Make roles configurable through environment variables instead of hardcoding them.

* **diplo.py**
  - Add environment variables for roles `DIPLO_UMPIRE_ROLE`, `SPECTATOR_ROLE`, `DIPLOMAT_ROLE`, `BANKER_ROLE`, `NEWSPAPER_WRITER_ROLE`, and `CAPTURED_ROLE`.
  - Replace hardcoded role names with environment variables in `send_letter` function.

* **loans.py**
  - Add environment variables for roles `DIPLO_UMPIRE_ROLE` and `SPECTATOR_ROLE`.
  - Replace hardcoded role names with environment variables in `submit_bid` function.

* **.env**
  - Add environment variables `DIPLO_UMPIRE_ROLE`, `SPECTATOR_ROLE`, `DIPLOMAT_ROLE`, `BANKER_ROLE`, `NEWSPAPER_WRITER_ROLE`, and `CAPTURED_ROLE`.

* **README.md**
  - Update to include new environment variables for roles.

